### PR TITLE
Remove max attribute when jump to backward

### DIFF
--- a/src/components/atoms/RelativeDateInput.vue
+++ b/src/components/atoms/RelativeDateInput.vue
@@ -172,8 +172,11 @@ export default class RelativeDateInput extends Vue {
     else return availableUnits[availableUnits.length - 1]
   }
 
-  get maxTargetNumber (): number {
-    const { targetUnit, actualUx, targetDate } = this
+  get maxTargetNumber (): number | boolean {
+    const { isJumpForward, targetUnit, actualUx, targetDate } = this
+    if (!isJumpForward) {
+      return false
+    }
     return targetUnit.diff(new Date(actualUx.date), targetDate)
   }
 


### PR DESCRIPTION
後ろにジャンプしたいのに、actualUx.dateとactualUx.dateのdiffをとってmax=0が指定されて後ろにジャンプできなかったのを直した